### PR TITLE
Require GitHub issues to have a template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
You can also add links with descriptions, such as to the documentation repo, rvx-builder issue page, or social platforms. These will apear on the issue template menu page.